### PR TITLE
Add check-dist workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,11 +39,21 @@ jobs:
       with:
         node-version: '16.x'
 
-    - name: Install packages
+    - name: Get npm cache directory
+      id: npm-cache-dir
       shell: pwsh
-      run: |
-        npm install --global @vercel/ncc
-        npm ci
+      run: echo "dir=$(npm config get cache)" >> ${env:GITHUB_OUTPUT}
+
+    - name: Setup npm cache
+      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      id: npm-cache
+      with:
+        path: ${{ steps.npm-cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: ${{ runner.os }}-node-
+
+    - name: Install packages
+      run: npm ci
 
     - name: Build and Test
       shell: pwsh

--- a/.github/workflows/check-dist-failed.yml
+++ b/.github/workflows/check-dist-failed.yml
@@ -1,0 +1,39 @@
+name: check-dist-failed
+
+on:
+  workflow_run:
+    workflows: [ check-dist ]
+    types: [ completed ]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  comment:
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Add comment
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.payload.workflow_run.head_sha,
+            });
+            if (prs.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prs[0].number,
+                body: `Hi @${prs[0].user.login} :wave:\n\nIt looks like this pull request makes changes which require the contents of \`dist\` to be updated, but these files have not been included with your changes.\n\nPlease run \`build.ps1\` and commit the changes made to the \`dist\` directory to your branch and push them to this pull request.`,
+              });
+            }

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -1,0 +1,69 @@
+name: check-dist
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'src/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'src/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-dist:
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Setup Node
+        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
+        with:
+          node-version: '16.x'
+
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        shell: pwsh
+        run: echo "dir=$(npm config get cache)" >> ${env:GITHUB_OUTPUT}
+
+      - name: Setup npm cache
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        id: npm-cache
+        with:
+            path: ${{ steps.npm-cache-dir.outputs.dir }}
+            key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+            restore-keys: ${{ runner.os }}-node-
+
+      - name: Install packages
+        run: npm ci
+
+      - name: Rebuild the dist directory
+        run: npm run check-dist
+
+      - name: Compare the expected and actual dist directories
+        id: diff
+        run: |
+          if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
+            echo "::error::Detected uncommitted changes to dist."
+            echo "Detected uncommitted changes after build.  See status below:"
+            git diff
+            exit 1
+          fi
+      - name: Upload generated dist
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        if: ${{ failure() && steps.diff.conclusion == 'failure' }}
+        with:
+          name: dist
+          path: dist/

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "lib/main.js",
   "scripts": {
     "build": "tsc",
+    "check-dist": "npm run build && npm run package",
     "format": "prettier --write src/**/*.ts tests/**/*.ts",
     "format-check": "prettier --check src/**/*.ts tests/**/*.ts",
     "lint": "eslint src/**/*.ts",


### PR DESCRIPTION
- Add a workflow that verifies that `dist` has been committed when changes are made that might change it.
- Add a workflow that leaves a comment if the new workflow fails.
- Add npm package cache to build.
- Remove redundant package installation.
