### PR TITLE
Update to Node.js v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,5 +56,5 @@ outputs:
   pulls-opened:
     description: 'A JSON array of the numbers of any pull requests that were opened to update static assets.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "update-static-assets",
-  "version": "1.2.3",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "update-static-assets",
-      "version": "1.2.3",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "update-static-assets",
-  "version": "1.2.3",
+  "version": "2.0.0",
   "private": true,
   "description": "A GitHub Action that updates HTML static assets.",
   "main": "lib/main.js",


### PR DESCRIPTION
Update the action to use [the Node.js v20 runtime](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) in GitHub Actions.
