### PR TITLE
Mark generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * text=auto
 *.sh eol=lf
+dist/ linguist-generated=true


### PR DESCRIPTION
Mark all the files in `dist` as generated so they're auto collapsed in GitHub diffs.
