### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 * text=auto
 *.sh eol=lf
-dist/* linguist-generated
+dist/* eol=lf linguist-generated


### PR DESCRIPTION
Use `eof=lf` for files in `dist` to avoid phantom changes when working on Windows after regenerating files.
